### PR TITLE
Make setToday not override visibleMonth if already set

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -88,7 +88,16 @@ initWithToday today =
 -}
 setToday : Date -> Model -> Model
 setToday today (Model picker) =
-    Model { picker | today = today, visibleMonth = today }
+    Model
+        { picker
+            | today = today
+            , visibleMonth =
+                if picker.visibleMonth == Date.fromOrdinalDate 1 1 then
+                    today
+
+                else
+                    picker.visibleMonth
+        }
 
 
 {-| Closes the date picker.
@@ -331,7 +340,7 @@ type alias Config msg =
     }
 
 
-{-| Use it like you would `Input.text`, the attributes, `text`, `placeholder` and `label` will behave 
+{-| Use it like you would `Input.text`, the attributes, `text`, `placeholder` and `label` will behave
 exactly like for `Input.text`. It has however a more complex `onChange`, a `selected` date, the internal `model` and some `settings`.
 
 **Note**: `Events.onClick`, `Events.onFocus` and `Events.onLoseFocus` are used internally by the date picker.

--- a/tests/DatePickerTests.elm
+++ b/tests/DatePickerTests.elm
@@ -134,6 +134,25 @@ initSetTodayIsInitWithToday =
             Expect.equal setToday withToday
 
 
+setTodayDontOverrideVisibleMonthIfSet : Test
+setTodayDontOverrideVisibleMonthIfSet =
+    fuzz2 (intRange 1000 3000) (intRange 1 334) "init + setToday = initWithToday" <|
+        \year day ->
+            let
+                date =
+                    Date.fromOrdinalDate year day
+
+                visibleMonth =
+                    Date.fromOrdinalDate year 336
+
+                model =
+                    DatePicker.init
+                        |> DatePicker.setVisibleMonth visibleMonth
+                        |> DatePicker.setToday date
+            in
+            isVisibleMonth visibleMonth model
+
+
 todayIsVisibleOnInit : Test
 todayIsVisibleOnInit =
     fuzz2 (intRange 1000 3000) (intRange 1 366) "today is visible month" <|
@@ -309,11 +328,14 @@ clickDisabled =
                 |> Event.simulate Event.click
                 |> Event.toResult
                 |> Expect.err
-                -- |> Event.expect
-                --     (DatePickerChanged <|
-                --         DatePicker.DateChanged <|
-                --             Date.fromCalendarDate (Date.year date) (Date.month date) dayToSelect
-                --     )
+
+
+
+-- |> Event.expect
+--     (DatePickerChanged <|
+--         DatePicker.DateChanged <|
+--             Date.fromCalendarDate (Date.year date) (Date.month date) dayToSelect
+--     )
 
 
 intTo2DigitString : Int -> String


### PR DESCRIPTION
If the visibleMonth is already set, setting 'today' should not change it.
It allows to set 'today' after setting 'visibleMonth' to, for example, the currently selected date.